### PR TITLE
update egui to 0.26.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_glium"
-version = "0.23.0"
+version = "0.26.2"
 authors = ["Emil Ernerfeldt <emil.ernerfeldt@gmail.com>"]
 description = "Bindings for using egui natively using the glium library"
 edition = "2021"
@@ -29,19 +29,19 @@ links = ["egui-winit/links"]
 
 
 [dependencies]
-egui = { version = "0.23.0", default-features = false, features = [
+egui = { version = "0.26.2", default-features = false, features = [
   "bytemuck",
   "default_fonts"
 ] }
-egui-winit = { version = "0.23.0", default-features = false }
+egui-winit = { version = "0.26.2", default-features = false }
 
 ahash = { version = "0.8.1", default-features = false, features = [
   "no-rng", # we don't need DOS-protection, so we let users opt-in to it instead
   "std",
 ] }
 bytemuck = "1.7"
-glium = "0.33"
-winit = "0.28"
+glium = "0.34"
+winit = "0.29"
 
 #! ### Optional dependencies
 ## Enable this when generating docs.
@@ -49,5 +49,5 @@ document-features = { version = "0.2", optional = true }
 
 
 [dev-dependencies]
-egui_demo_lib = { version = "0.23.0", default-features = false }
+egui_demo_lib = { version = "0.26.2", default-features = false }
 image = { version = "0.24", default-features = false, features = ["png"] }

--- a/examples/native_texture.rs
+++ b/examples/native_texture.rs
@@ -1,14 +1,15 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
-use egui::load::SizedTexture;
+use egui::{load::SizedTexture, ViewportId};
 use glium::{backend::glutin::SimpleWindowBuilder, glutin::surface::WindowSurface};
-use winit::event_loop::{self, EventLoop, EventLoopBuilder};
+use winit::event_loop::{EventLoop, EventLoopBuilder};
 
 fn main() {
-    let event_loop = EventLoopBuilder::with_user_event().build();
+    let event_loop = EventLoopBuilder::with_user_event().build().unwrap();
     let (window, display) = create_display(&event_loop);
 
-    let mut egui_glium = egui_glium::EguiGlium::new(&display, &window, &event_loop);
+    let mut egui_glium =
+        egui_glium::EguiGlium::new(ViewportId::ROOT, &display, &window, &event_loop);
 
     let png_data = include_bytes!("rust-logo-256x256.png");
     let image = load_glium_image(png_data);
@@ -24,11 +25,11 @@ fn main() {
     // Setup button image size for reasonable image size for button container.
     let button_image_size = egui::vec2(32_f32, 32_f32);
 
-    event_loop.run(move |event, _, control_flow| {
+    let result = event_loop.run(move |event, target| {
         let mut redraw = || {
             let mut quit = false;
 
-            let repaint_after = egui_glium.run(&window, |egui_ctx| {
+            egui_glium.run(&window, |egui_ctx| {
                 egui::SidePanel::left("my_side_panel").show(egui_ctx, |ui| {
                     if ui
                         .add(egui::Button::image_and_text(
@@ -45,18 +46,9 @@ fn main() {
                 });
             });
 
-            *control_flow = if quit {
-                event_loop::ControlFlow::Exit
-            } else if repaint_after.is_zero() {
-                window.request_redraw();
-                event_loop::ControlFlow::Poll
-            } else if let Some(repaint_after_instant) =
-                std::time::Instant::now().checked_add(repaint_after)
-            {
-                event_loop::ControlFlow::WaitUntil(repaint_after_instant)
-            } else {
-                event_loop::ControlFlow::Wait
-            };
+            if quit {
+                target.exit()
+            }
 
             {
                 use glium::Surface as _;
@@ -76,25 +68,18 @@ fn main() {
         };
 
         match event {
-            // Platform-dependent event handlers to workaround a winit bug
-            // See: https://github.com/rust-windowing/winit/issues/987
-            // See: https://github.com/rust-windowing/winit/issues/1619
-            winit::event::Event::RedrawEventsCleared if cfg!(target_os = "windows") => redraw(),
-            winit::event::Event::RedrawRequested(_) if !cfg!(target_os = "windows") => redraw(),
-
             winit::event::Event::WindowEvent { event, .. } => {
                 use winit::event::WindowEvent;
                 match &event {
-                    WindowEvent::CloseRequested | WindowEvent::Destroyed => {
-                        *control_flow = winit::event_loop::ControlFlow::Exit;
-                    }
+                    WindowEvent::CloseRequested | WindowEvent::Destroyed => target.exit(),
                     WindowEvent::Resized(new_size) => {
                         display.resize((*new_size).into());
                     }
+                    WindowEvent::RedrawRequested => redraw(),
                     _ => {}
                 }
 
-                let event_response = egui_glium.on_event(&event);
+                let event_response = egui_glium.on_event(&window, &event);
 
                 if event_response.repaint {
                     window.request_redraw();
@@ -110,6 +95,7 @@ fn main() {
             _ => (),
         }
     });
+    result.unwrap()
 }
 
 fn create_display(


### PR DESCRIPTION
Updates `egui_glium` dependencies to egui 0.26.2 and glium 0.34 respectively.

### Breaking changes

* uses of `egui_glium.egui_ctx` are now `egui_glium.egui_ctx()`
* The `EguiGlium::new` function has a `ViewportId` argument that you can normally just set to `ViewportId::ROOT`, see https://github.com/emilk/egui/pull/3172
* `EguiGlium::run` no longer returns `repaint_requested` as repaints are handled through another mechanism now. (Not sure exactly how it is supposed to work...) See https://github.com/emilk/egui/pull/3172 