### PR TITLE
Replace `eprintln!` calls with `log::info!`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target/
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ ahash = { version = "0.8.1", default-features = false, features = [
 bytemuck = "1.7"
 glium = "0.34"
 winit = "0.29"
+log = "0.4.21"
 
 #! ### Optional dependencies
 ## Enable this when generating docs.

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -58,7 +58,7 @@ impl Painter {
             .get_context()
             .is_glsl_version_supported(&glium::Version(glium::Api::Gl, 1, 4))
         {
-            eprintln!("Using GL 1.4");
+            log::info!("Using GL 1.4");
             create_program(
                 facade,
                 include_str!("shader/vertex_140.glsl"),
@@ -68,7 +68,7 @@ impl Painter {
             .get_context()
             .is_glsl_version_supported(&glium::Version(glium::Api::Gl, 1, 2))
         {
-            eprintln!("Using GL 1.2");
+            log::info!("Using GL 1.2");
             create_program(
                 facade,
                 include_str!("shader/vertex_120.glsl"),
@@ -78,7 +78,7 @@ impl Painter {
             .get_context()
             .is_glsl_version_supported(&glium::Version(glium::Api::GlEs, 3, 0))
         {
-            eprintln!("Using GL ES 3.0");
+            log::info!("Using GL ES 3.0");
             create_program(
                 facade,
                 include_str!("shader/vertex_300es.glsl"),
@@ -88,7 +88,7 @@ impl Painter {
             .get_context()
             .is_glsl_version_supported(&glium::Version(glium::Api::GlEs, 1, 0))
         {
-            eprintln!("Using GL ES 1.0");
+            log::info!("Using GL ES 1.0");
             create_program(
                 facade,
                 include_str!("shader/vertex_100es.glsl"),


### PR DESCRIPTION
This pull request replaces the `eprintln!` calls in `painter.rs` which notify the user of the current version of OpenGL with calls to `log::info!`.

This change allows for downstream users to decide if and how they would like to print this message to the console.

Thanks for making this library.