### PR TITLE
Upgrade to egui v0.29.1 and glium v0.36.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,3 +46,4 @@ document-features = { version = "0.2", optional = true }
 [dev-dependencies]
 egui_demo_lib = { version = "0.29.1", default-features = false }
 image = { version = "0.25.4", default-features = false, features = ["png"] }
+egui = { version = "0.29.1", default-features = false, features = ["default_fonts"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,11 @@ links = ["egui-winit/links"]
 
 
 [dependencies]
-egui = { version = "0.26.2", default-features = false, features = [
+egui = { version = "0.28.1", default-features = false, features = [
   "bytemuck",
   "default_fonts"
 ] }
-egui-winit = { version = "0.26.2", default-features = false }
+egui-winit = { version = "0.28.1", default-features = false }
 
 ahash = { version = "0.8.1", default-features = false, features = [
   "no-rng", # we don't need DOS-protection, so we let users opt-in to it instead

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_glium"
-version = "0.28.1"
+version = "0.29.1"
 authors = ["Emil Ernerfeldt <emil.ernerfeldt@gmail.com>"]
 description = "Bindings for using egui natively using the glium library"
 edition = "2021"
@@ -29,20 +29,13 @@ links = ["egui-winit/links"]
 
 
 [dependencies]
-#egui = { version = "0.28.1", default-features = false, features = [
-#  "bytemuck",
-#  "default_fonts"
-#] }
-#egui-winit = { version = "0.28.1", default-features = false }
-
 ahash = { version = "0.8.1", default-features = false, features = [
   "no-rng", # we don't need DOS-protection, so we let users opt-in to it instead
   "std",
 ] }
-bytemuck = "1.7"
-glium = "0.35.0"
-#winit = "0.30.4"
-egui-winit = { git = "https://github.com/emilk/egui" }
+bytemuck = { version = "1.7", features = ["derive"] }
+egui-winit = { version = "0.29.1", default-features = false, features = ["bytemuck"] }
+glium = "0.36.0"
 log = "0.4.21"
 
 #! ### Optional dependencies
@@ -51,8 +44,5 @@ document-features = { version = "0.2", optional = true }
 
 
 [dev-dependencies]
-egui_demo_lib = { version = "0.26.2", default-features = false }
-image = { version = "0.24", default-features = false, features = ["png"] }
-
-#[dependencies.egui-winit]
-#path = "../egui/crates/egui-winit/"
+egui_demo_lib = { version = "0.29.1", default-features = false }
+image = { version = "0.25.4", default-features = false, features = ["png"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_glium"
-version = "0.26.3"
+version = "0.28.1"
 authors = ["Emil Ernerfeldt <emil.ernerfeldt@gmail.com>"]
 description = "Bindings for using egui natively using the glium library"
 edition = "2021"
@@ -29,19 +29,20 @@ links = ["egui-winit/links"]
 
 
 [dependencies]
-egui = { version = "0.28.1", default-features = false, features = [
-  "bytemuck",
-  "default_fonts"
-] }
-egui-winit = { version = "0.28.1", default-features = false }
+#egui = { version = "0.28.1", default-features = false, features = [
+#  "bytemuck",
+#  "default_fonts"
+#] }
+#egui-winit = { version = "0.28.1", default-features = false }
 
 ahash = { version = "0.8.1", default-features = false, features = [
   "no-rng", # we don't need DOS-protection, so we let users opt-in to it instead
   "std",
 ] }
 bytemuck = "1.7"
-glium = "0.34"
-winit = "0.29"
+glium = "0.35.0"
+#winit = "0.30.4"
+egui-winit = { git = "https://github.com/emilk/egui" }
 log = "0.4.21"
 
 #! ### Optional dependencies
@@ -52,3 +53,6 @@ document-features = { version = "0.2", optional = true }
 [dev-dependencies]
 egui_demo_lib = { version = "0.26.2", default-features = false }
 image = { version = "0.24", default-features = false, features = ["png"] }
+
+#[dependencies.egui-winit]
+#path = "../egui/crates/egui-winit/"

--- a/examples/native_texture.rs
+++ b/examples/native_texture.rs
@@ -1,11 +1,12 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
+use egui_winit::{egui, winit};
 use egui::{load::SizedTexture, ViewportId};
 use glium::{backend::glutin::SimpleWindowBuilder, glutin::surface::WindowSurface};
-use winit::event_loop::{EventLoop, EventLoopBuilder};
+use winit::event_loop::EventLoop;
 
 fn main() {
-    let event_loop = EventLoopBuilder::with_user_event().build().unwrap();
+    let event_loop = EventLoop::new().unwrap();
     let (window, display) = create_display(&event_loop);
 
     let mut egui_glium =
@@ -25,6 +26,7 @@ fn main() {
     // Setup button image size for reasonable image size for button container.
     let button_image_size = egui::vec2(32_f32, 32_f32);
 
+    #[allow(deprecated)]
     let result = event_loop.run(move |event, target| {
         let mut redraw = || {
             let mut quit = false;
@@ -102,7 +104,7 @@ fn create_display(
     event_loop: &EventLoop<()>,
 ) -> (winit::window::Window, glium::Display<WindowSurface>) {
     SimpleWindowBuilder::new()
-        .set_window_builder(winit::window::WindowBuilder::new().with_resizable(true))
+        .set_window_builder(winit::window::WindowAttributes::default().with_resizable(true))
         .with_inner_size(800, 600)
         .with_title("egui_glium example")
         .build(event_loop)

--- a/examples/pure_glium.rs
+++ b/examples/pure_glium.rs
@@ -2,15 +2,13 @@
 
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
+use egui_winit::{egui, winit};
 use egui::ViewportId;
 use glium::{backend::glutin::SimpleWindowBuilder, glutin::surface::WindowSurface};
-use winit::{
-    event,
-    event_loop::{EventLoop, EventLoopBuilder},
-};
+use winit::{event, event_loop::EventLoop};
 
 fn main() {
-    let event_loop = EventLoopBuilder::with_user_event().build().unwrap();
+    let event_loop = EventLoop::new().unwrap();
     let (window, display) = create_display(&event_loop);
 
     let mut egui_glium =
@@ -18,6 +16,7 @@ fn main() {
 
     let mut color_test = egui_demo_lib::ColorTest::default();
 
+    #[allow(deprecated)]
     let result = event_loop.run(move |event, target| {
         let mut redraw = || {
             let mut quit = false;
@@ -89,7 +88,7 @@ fn create_display(
     event_loop: &EventLoop<()>,
 ) -> (winit::window::Window, glium::Display<WindowSurface>) {
     SimpleWindowBuilder::new()
-        .set_window_builder(winit::window::WindowBuilder::new().with_resizable(true))
+        .set_window_builder(winit::window::WindowAttributes::default().with_resizable(true))
         .with_inner_size(800, 600)
         .with_title("egui_glium example")
         .build(event_loop)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,12 +13,12 @@
 #![forbid(unsafe_code)]
 
 mod painter;
-use glium::glutin::surface::WindowSurface;
+use glium::{glutin::surface::WindowSurface, winit};
 pub use painter::Painter;
 
 pub use egui_winit;
 
-use egui_winit::winit::event_loop::EventLoopWindowTarget;
+use egui_winit::{egui, egui::ViewportId, winit::event_loop::EventLoop};
 pub use egui_winit::EventResponse;
 
 // ----------------------------------------------------------------------------
@@ -34,10 +34,10 @@ pub struct EguiGlium {
 
 impl EguiGlium {
     pub fn new<E>(
-        viewport_id: egui::ViewportId,
+        viewport_id: ViewportId,
         display: &glium::Display<WindowSurface>,
-        window: &winit::window::Window,
-        event_loop: &EventLoopWindowTarget<E>,
+        window: &glium::winit::window::Window,
+        event_loop: &EventLoop<E>,
     ) -> Self {
         let painter = crate::Painter::new(display);
 
@@ -47,6 +47,7 @@ impl EguiGlium {
             viewport_id,
             event_loop,
             Some(pixels_per_point),
+            None,
             Some(painter.max_texture_side()),
         );
 
@@ -58,7 +59,7 @@ impl EguiGlium {
         }
     }
 
-    pub fn egui_ctx(&self) -> &egui::Context {
+    pub fn egui_ctx(&self) -> &egui_winit::egui::Context {
         self.egui_winit.egui_ctx()
     }
 
@@ -73,9 +74,9 @@ impl EguiGlium {
     /// Runs the main egui render.
     ///
     /// Call [`Self::paint`] later to paint.
-    pub fn run(&mut self, window: &winit::window::Window, run_ui: impl FnMut(&egui::Context)) {
+    pub fn run(&mut self, window: &glium::winit::window::Window, run_ui: impl FnMut(&egui_winit::egui::Context)) {
         let raw_input = self.egui_winit.take_egui_input(window);
-        let egui::FullOutput {
+        let egui_winit::egui::FullOutput {
             platform_output,
             textures_delta,
             shapes,

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -1,14 +1,15 @@
 #![allow(deprecated)] // legacy implement_vertex macro
 #![allow(semicolon_in_expressions_from_macros)] // glium::program! macro
 
-use egui::{
+use egui_winit::egui;
+use egui_winit::egui::{
     epaint::{textures::TextureFilter, Primitive},
     TextureOptions,
 };
 use glium::glutin::surface::WindowSurface;
 
 use {
-    egui::{emath::Rect, epaint::Mesh},
+    egui_winit::egui::{emath::Rect, epaint::Mesh},
     glium::{
         implement_vertex,
         index::PrimitiveType,


### PR DESCRIPTION
This pull request upgrades the following dependencies to the latest:
 - `egui` to 0.29.1
 - `glium` to 0.36.0
 - `image` to 0.25.4 (dev dependency for the `native_texture` example) 

This pull request also includes a rearrange on the imports for all code to make the style more consistent and self-explanative. If such change is not appreciated, I'd open another pull request containing the dependency upgrades only.

Btw, if this crate is looking for some kind of active maintainer, I'm more than willing to help. I'm a graphics dev with experience of authoring and active maintaining `egui-directx11`.