### PR TITLE
Ecosystem Update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,19 +29,19 @@ links = ["egui-winit/links"]
 
 
 [dependencies]
-egui = { version = "0.26.2", default-features = false, features = [
+egui = { version = "0.29", default-features = false, features = [
   "bytemuck",
   "default_fonts"
 ] }
-egui-winit = { version = "0.26.2", default-features = false }
+egui-winit = { version = "0.29", default-features = false }
 
 ahash = { version = "0.8.1", default-features = false, features = [
   "no-rng", # we don't need DOS-protection, so we let users opt-in to it instead
   "std",
 ] }
 bytemuck = "1.7"
-glium = "0.34"
-winit = "0.29"
+glium = "0.36"
+winit = "0.30"
 log = "0.4.21"
 
 #! ### Optional dependencies
@@ -50,5 +50,5 @@ document-features = { version = "0.2", optional = true }
 
 
 [dev-dependencies]
-egui_demo_lib = { version = "0.26.2", default-features = false }
+egui_demo_lib = { version = "0.29", default-features = false }
 image = { version = "0.24", default-features = false, features = ["png"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ bytemuck = "1.7"
 glium = "0.36"
 winit = "0.30"
 log = "0.4.21"
+raw-window-handle = "0.6"
 
 #! ### Optional dependencies
 ## Enable this when generating docs.

--- a/examples/native_texture.rs
+++ b/examples/native_texture.rs
@@ -17,7 +17,7 @@ fn main() {
 
     let (window, display) = create_display(&event_loop);
 
-    let mut egui_glium_instance =
+    let mut egui_glium =
         egui_glium::EguiGlium::new(ViewportId::ROOT, &display, &window, &event_loop);
 
     let png_data = include_bytes!("rust-logo-256x256.png");
@@ -28,7 +28,7 @@ fn main() {
     // Allow us to share the texture with egui:
     let glium_texture = std::rc::Rc::new(glium_texture);
     // Allocate egui's texture id for GL texture
-    let texture_id = egui_glium_instance
+    let texture_id = egui_glium
         .painter
         .register_native_texture(Rc::clone(&glium_texture), Default::default());
 
@@ -36,7 +36,7 @@ fn main() {
     let button_image_size = egui::vec2(32_f32, 32_f32);
 
     let mut app = App {
-        egui_glium_instance,
+        egui_glium,
         _glium_texture: glium_texture,
         texture_id,
         image_size,
@@ -50,7 +50,7 @@ fn main() {
 }
 
 struct App {
-    egui_glium_instance: egui_glium::EguiGlium,
+    egui_glium: egui_glium::EguiGlium,
     _glium_texture: Rc<SrgbTexture2d>,
     texture_id: TextureId,
     image_size: Vec2,
@@ -66,7 +66,7 @@ impl ApplicationHandler for App {
         let mut redraw = || {
             let mut quit = false;
 
-            self.egui_glium_instance.run(&self.window, |egui_ctx| {
+            self.egui_glium.run(&self.window, |egui_ctx| {
                 egui::SidePanel::left("my_side_panel").show(egui_ctx, |ui| {
                     if ui
                         .add(egui::Button::image_and_text(
@@ -96,7 +96,7 @@ impl ApplicationHandler for App {
 
                 // draw things behind egui here
 
-                self.egui_glium_instance.paint(&self.display, &mut target);
+                self.egui_glium.paint(&self.display, &mut target);
 
                 // draw things on top of egui here
 
@@ -114,7 +114,7 @@ impl ApplicationHandler for App {
             _ => {}
         }
 
-        let event_response = self.egui_glium_instance.on_event(&self.window, &event);
+        let event_response = self.egui_glium.on_event(&self.window, &event);
 
         if event_response.repaint {
             self.window.request_redraw();

--- a/examples/native_texture.rs
+++ b/examples/native_texture.rs
@@ -13,22 +13,18 @@ use winit::{
 };
 
 fn main() {
-    let event_loop = EventLoop::<()>::with_user_event().build().unwrap();
+    let event_loop = EventLoop::new().unwrap();
 
-    let (window, glium_display) = SimpleWindowBuilder::new()
-        .set_window_builder(Window::default_attributes().with_resizable(true))
-        .with_inner_size(800, 600)
-        .with_title("egui_glium example")
-        .build(&event_loop);
+    let (window, display) = create_display(&event_loop);
 
     let mut egui_glium_instance =
-        egui_glium::EguiGlium::new(ViewportId::ROOT, &glium_display, &window, &event_loop);
+        egui_glium::EguiGlium::new(ViewportId::ROOT, &display, &window, &event_loop);
 
     let png_data = include_bytes!("rust-logo-256x256.png");
     let image = load_glium_image(png_data);
     let image_size = egui::vec2(image.width as f32, image.height as f32);
     // Load to gpu memory
-    let glium_texture = glium::texture::SrgbTexture2d::new(&glium_display, image).unwrap();
+    let glium_texture = glium::texture::SrgbTexture2d::new(&display, image).unwrap();
     // Allow us to share the texture with egui:
     let glium_texture = std::rc::Rc::new(glium_texture);
     // Allocate egui's texture id for GL texture
@@ -45,7 +41,7 @@ fn main() {
         texture_id,
         image_size,
         window,
-        display: glium_display,
+        display,
         button_image_size,
     };
 
@@ -130,6 +126,16 @@ impl ApplicationHandler for App {
             self.window.request_redraw();
         }
     }
+}
+
+fn create_display(
+    event_loop: &EventLoop<()>,
+) -> (winit::window::Window, glium::Display<WindowSurface>) {
+    SimpleWindowBuilder::new()
+        .set_window_builder(Window::default_attributes().with_resizable(true))
+        .with_inner_size(800, 600)
+        .with_title("egui_glium example")
+        .build(event_loop)
 }
 
 fn load_glium_image(png_data: &[u8]) -> glium::texture::RawImage2d<'_, u8> {

--- a/examples/pure_glium.rs
+++ b/examples/pure_glium.rs
@@ -16,13 +16,12 @@ fn main() {
 
     let (window, display) = create_display(&event_loop);
 
-    let egui_glium_instance =
-        egui_glium::EguiGlium::new(ViewportId::ROOT, &display, &window, &event_loop);
+    let egui_glium = egui_glium::EguiGlium::new(ViewportId::ROOT, &display, &window, &event_loop);
 
     let color_test = egui_demo_lib::ColorTest::default();
 
     let mut app = App {
-        egui_glium_instance,
+        egui_glium,
         window,
         display,
         color_test,
@@ -33,7 +32,7 @@ fn main() {
 }
 
 struct App {
-    egui_glium_instance: egui_glium::EguiGlium,
+    egui_glium: egui_glium::EguiGlium,
     window: winit::window::Window,
     display: glium::Display<WindowSurface>,
     color_test: egui_demo_lib::ColorTest,
@@ -46,7 +45,7 @@ impl ApplicationHandler for App {
         let mut redraw = || {
             let mut quit = false;
 
-            self.egui_glium_instance.run(&self.window, |egui_ctx| {
+            self.egui_glium.run(&self.window, |egui_ctx| {
                 egui::SidePanel::left("my_side_panel").show(egui_ctx, |ui| {
                     ui.heading("Hello World!");
                     if ui.button("Quit").clicked() {
@@ -74,7 +73,7 @@ impl ApplicationHandler for App {
 
                 // draw things behind egui here
 
-                self.egui_glium_instance.paint(&self.display, &mut target);
+                self.egui_glium.paint(&self.display, &mut target);
 
                 // draw things on top of egui here
 
@@ -92,7 +91,7 @@ impl ApplicationHandler for App {
             _ => {}
         }
 
-        let event_response = self.egui_glium_instance.on_event(&self.window, &event);
+        let event_response = self.egui_glium.on_event(&self.window, &event);
 
         if event_response.repaint {
             self.window.request_redraw();

--- a/examples/pure_glium.rs
+++ b/examples/pure_glium.rs
@@ -12,23 +12,19 @@ use winit::{
 };
 
 fn main() {
-    let event_loop = EventLoop::<()>::with_user_event().build().unwrap();
+    let event_loop = EventLoop::new().unwrap();
 
-    let (window, glium_display) = SimpleWindowBuilder::new()
-        .set_window_builder(Window::default_attributes().with_resizable(true))
-        .with_inner_size(800, 600)
-        .with_title("egui_glium example")
-        .build(&event_loop);
+    let (window, display) = create_display(&event_loop);
 
     let egui_glium_instance =
-        egui_glium::EguiGlium::new(ViewportId::ROOT, &glium_display, &window, &event_loop);
+        egui_glium::EguiGlium::new(ViewportId::ROOT, &display, &window, &event_loop);
 
     let color_test = egui_demo_lib::ColorTest::default();
 
     let mut app = App {
         egui_glium_instance,
         window,
-        display: glium_display,
+        display,
         color_test,
     };
 
@@ -108,4 +104,14 @@ impl ApplicationHandler for App {
             self.window.request_redraw();
         }
     }
+}
+
+fn create_display(
+    event_loop: &EventLoop<()>,
+) -> (winit::window::Window, glium::Display<WindowSurface>) {
+    SimpleWindowBuilder::new()
+        .set_window_builder(Window::default_attributes().with_resizable(true))
+        .with_inner_size(800, 600)
+        .with_title("egui_glium example")
+        .build(event_loop)
 }

--- a/examples/pure_glium.rs
+++ b/examples/pure_glium.rs
@@ -14,10 +14,21 @@ use winit::{
 fn main() {
     let event_loop = EventLoop::<()>::with_user_event().build().unwrap();
 
+    let (window, glium_display) = SimpleWindowBuilder::new()
+        .set_window_builder(Window::default_attributes().with_resizable(true))
+        .with_inner_size(800, 600)
+        .with_title("egui_glium example")
+        .build(&event_loop);
+
+    let egui_glium_instance =
+        egui_glium::EguiGlium::new(ViewportId::ROOT, &glium_display, &window, &event_loop);
+
     let color_test = egui_demo_lib::ColorTest::default();
 
     let mut app = App {
-        graphics_context: None,
+        egui_glium_instance,
+        window,
+        display: glium_display,
         color_test,
     };
 
@@ -26,73 +37,48 @@ fn main() {
 }
 
 struct App {
-    graphics_context: Option<GraphicsContext>,
-    color_test: egui_demo_lib::ColorTest,
-}
-
-struct GraphicsContext {
     egui_glium_instance: egui_glium::EguiGlium,
     window: winit::window::Window,
     display: glium::Display<WindowSurface>,
+    color_test: egui_demo_lib::ColorTest,
 }
 
 impl ApplicationHandler for App {
-    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
-        let (window, glium_display) = SimpleWindowBuilder::new()
-            .set_window_builder(Window::default_attributes().with_resizable(true))
-            .with_inner_size(800, 600)
-            .with_title("egui_glium example")
-            .build(event_loop);
-
-        let egui_glium_instance =
-            egui_glium::EguiGlium::new(ViewportId::ROOT, &glium_display, &window, event_loop);
-
-        self.graphics_context = Some(GraphicsContext {
-            egui_glium_instance,
-            window,
-            display: glium_display,
-        });
-    }
+    fn resumed(&mut self, _event_loop: &ActiveEventLoop) {}
 
     fn window_event(&mut self, event_loop: &ActiveEventLoop, _id: WindowId, event: WindowEvent) {
         let mut redraw = || {
             let mut quit = false;
 
-            if let Some(graphics_context) = &mut self.graphics_context {
-                graphics_context
-                    .egui_glium_instance
-                    .run(&graphics_context.window, |egui_ctx| {
-                        egui::SidePanel::left("my_side_panel").show(egui_ctx, |ui| {
-                            ui.heading("Hello World!");
-                            if ui.button("Quit").clicked() {
-                                quit = true;
-                            }
-                        });
+            self.egui_glium_instance.run(&self.window, |egui_ctx| {
+                egui::SidePanel::left("my_side_panel").show(egui_ctx, |ui| {
+                    ui.heading("Hello World!");
+                    if ui.button("Quit").clicked() {
+                        quit = true;
+                    }
+                });
 
-                        egui::CentralPanel::default().show(egui_ctx, |ui| {
-                            egui::ScrollArea::vertical().show(ui, |ui| {
-                                self.color_test.ui(ui);
-                            });
-                        });
+                egui::CentralPanel::default().show(egui_ctx, |ui| {
+                    egui::ScrollArea::vertical().show(ui, |ui| {
+                        self.color_test.ui(ui);
                     });
-            }
+                });
+            });
 
             if quit {
                 event_loop.exit()
             }
 
-            if let Some(context) = &mut self.graphics_context {
+            {
                 use glium::Surface as _;
-                let mut target = context.display.draw();
+                let mut target = self.display.draw();
 
                 let color = egui::Rgba::from_rgb(0.1, 0.3, 0.2);
                 target.clear_color(color[0], color[1], color[2], color[3]);
 
                 // draw things behind egui here
 
-                context
-                    .egui_glium_instance
-                    .paint(&context.display, &mut target);
+                self.egui_glium_instance.paint(&self.display, &mut target);
 
                 // draw things on top of egui here
 
@@ -104,30 +90,22 @@ impl ApplicationHandler for App {
         match &event {
             WindowEvent::CloseRequested | WindowEvent::Destroyed => event_loop.exit(),
             WindowEvent::Resized(new_size) => {
-                if let Some(graphics_context) = &mut self.graphics_context {
-                    graphics_context.display.resize((*new_size).into());
-                }
+                self.display.resize((*new_size).into());
             }
             WindowEvent::RedrawRequested => redraw(),
             _ => {}
         }
 
-        if let Some(graphics_context) = &mut self.graphics_context {
-            let event_response = graphics_context
-                .egui_glium_instance
-                .on_event(&graphics_context.window, &event);
+        let event_response = self.egui_glium_instance.on_event(&self.window, &event);
 
-            if event_response.repaint {
-                graphics_context.window.request_redraw();
-            }
+        if event_response.repaint {
+            self.window.request_redraw();
         }
     }
 
     fn new_events(&mut self, _event_loop: &ActiveEventLoop, cause: StartCause) {
         if let StartCause::ResumeTimeReached { .. } = cause {
-            if let Some(graphics_context) = &mut self.graphics_context {
-                graphics_context.window.request_redraw();
-            }
+            self.window.request_redraw();
         }
     }
 }

--- a/examples/pure_glium.rs
+++ b/examples/pure_glium.rs
@@ -2,12 +2,11 @@
 
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
-use crate::event::WindowEvent;
 use egui::ViewportId;
 use glium::{backend::glutin::SimpleWindowBuilder, glutin::surface::WindowSurface};
 use winit::{
     application::ApplicationHandler,
-    event::{self, StartCause},
+    event::{StartCause, WindowEvent},
     event_loop::{ActiveEventLoop, EventLoop},
     window::{Window, WindowId},
 };
@@ -101,7 +100,7 @@ impl ApplicationHandler for App {
             }
         };
 
-        use event::WindowEvent;
+        use winit::event::WindowEvent;
         match &event {
             WindowEvent::CloseRequested | WindowEvent::Destroyed => event_loop.exit(),
             WindowEvent::Resized(new_size) => {

--- a/examples/pure_glium.rs
+++ b/examples/pure_glium.rs
@@ -2,55 +2,98 @@
 
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
+use crate::event::WindowEvent;
 use egui::ViewportId;
 use glium::{backend::glutin::SimpleWindowBuilder, glutin::surface::WindowSurface};
 use winit::{
-    event,
-    event_loop::{EventLoop, EventLoopBuilder},
+    application::ApplicationHandler,
+    event::{self, StartCause},
+    event_loop::{ActiveEventLoop, EventLoop},
+    window::{Window, WindowId},
 };
 
 fn main() {
-    let event_loop = EventLoopBuilder::with_user_event().build().unwrap();
-    let (window, display) = create_display(&event_loop);
+    let event_loop = EventLoop::<()>::with_user_event().build().unwrap();
 
-    let mut egui_glium =
-        egui_glium::EguiGlium::new(ViewportId::ROOT, &display, &window, &event_loop);
+    let color_test = egui_demo_lib::ColorTest::default();
 
-    let mut color_test = egui_demo_lib::ColorTest::default();
+    let mut app = App {
+        graphics_context: None,
+        color_test,
+    };
 
-    let result = event_loop.run(move |event, target| {
+    let result = event_loop.run_app(&mut app);
+    result.unwrap()
+}
+
+struct App {
+    graphics_context: Option<GraphicsContext>,
+    color_test: egui_demo_lib::ColorTest,
+}
+
+struct GraphicsContext {
+    egui_glium_instance: egui_glium::EguiGlium,
+    window: winit::window::Window,
+    display: glium::Display<WindowSurface>,
+}
+
+impl ApplicationHandler for App {
+    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+        let (window, glium_display) = SimpleWindowBuilder::new()
+            .set_window_builder(Window::default_attributes().with_resizable(true))
+            .with_inner_size(800, 600)
+            .with_title("egui_glium example")
+            .build(event_loop);
+
+        let egui_glium_instance =
+            egui_glium::EguiGlium::new(ViewportId::ROOT, &glium_display, &window, event_loop);
+
+        self.graphics_context = Some(GraphicsContext {
+            egui_glium_instance,
+            window,
+            display: glium_display,
+        });
+    }
+
+    fn window_event(&mut self, event_loop: &ActiveEventLoop, _id: WindowId, event: WindowEvent) {
         let mut redraw = || {
             let mut quit = false;
 
-            egui_glium.run(&window, |egui_ctx| {
-                egui::SidePanel::left("my_side_panel").show(egui_ctx, |ui| {
-                    ui.heading("Hello World!");
-                    if ui.button("Quit").clicked() {
-                        quit = true;
-                    }
-                });
+            if let Some(graphics_context) = &mut self.graphics_context {
+                graphics_context
+                    .egui_glium_instance
+                    .run(&graphics_context.window, |egui_ctx| {
+                        egui::SidePanel::left("my_side_panel").show(egui_ctx, |ui| {
+                            ui.heading("Hello World!");
+                            if ui.button("Quit").clicked() {
+                                quit = true;
+                            }
+                        });
 
-                egui::CentralPanel::default().show(egui_ctx, |ui| {
-                    egui::ScrollArea::vertical().show(ui, |ui| {
-                        color_test.ui(ui);
+                        egui::CentralPanel::default().show(egui_ctx, |ui| {
+                            egui::ScrollArea::vertical().show(ui, |ui| {
+                                self.color_test.ui(ui);
+                            });
+                        });
                     });
-                });
-            });
-
-            if quit {
-                target.exit()
             }
 
-            {
+            if quit {
+                event_loop.exit()
+            }
+
+            if let Some(context) = &mut self.graphics_context {
                 use glium::Surface as _;
-                let mut target = display.draw();
+                let mut target = context.display.draw();
 
                 let color = egui::Rgba::from_rgb(0.1, 0.3, 0.2);
                 target.clear_color(color[0], color[1], color[2], color[3]);
 
                 // draw things behind egui here
 
-                egui_glium.paint(&display, &mut target);
+                context
+                    .egui_glium_instance
+                    .paint(&context.display, &mut target);
 
                 // draw things on top of egui here
 
@@ -58,39 +101,34 @@ fn main() {
             }
         };
 
-        match event {
-            event::Event::WindowEvent { event, .. } => {
-                use event::WindowEvent;
-                match &event {
-                    WindowEvent::CloseRequested | WindowEvent::Destroyed => target.exit(),
-                    WindowEvent::Resized(new_size) => {
-                        display.resize((*new_size).into());
-                    }
-                    WindowEvent::RedrawRequested => redraw(),
-                    _ => {}
-                }
-
-                let event_response = egui_glium.on_event(&window, &event);
-
-                if event_response.repaint {
-                    window.request_redraw();
+        use event::WindowEvent;
+        match &event {
+            WindowEvent::CloseRequested | WindowEvent::Destroyed => event_loop.exit(),
+            WindowEvent::Resized(new_size) => {
+                if let Some(graphics_context) = &mut self.graphics_context {
+                    graphics_context.display.resize((*new_size).into());
                 }
             }
-            event::Event::NewEvents(event::StartCause::ResumeTimeReached { .. }) => {
-                window.request_redraw();
-            }
-            _ => (),
+            WindowEvent::RedrawRequested => redraw(),
+            _ => {}
         }
-    });
-    result.unwrap()
-}
 
-fn create_display(
-    event_loop: &EventLoop<()>,
-) -> (winit::window::Window, glium::Display<WindowSurface>) {
-    SimpleWindowBuilder::new()
-        .set_window_builder(winit::window::WindowBuilder::new().with_resizable(true))
-        .with_inner_size(800, 600)
-        .with_title("egui_glium example")
-        .build(event_loop)
+        if let Some(graphics_context) = &mut self.graphics_context {
+            let event_response = graphics_context
+                .egui_glium_instance
+                .on_event(&graphics_context.window, &event);
+
+            if event_response.repaint {
+                graphics_context.window.request_redraw();
+            }
+        }
+    }
+
+    fn new_events(&mut self, _event_loop: &ActiveEventLoop, cause: StartCause) {
+        if let StartCause::ResumeTimeReached { .. } = cause {
+            if let Some(graphics_context) = &mut self.graphics_context {
+                graphics_context.window.request_redraw();
+            }
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ pub use painter::Painter;
 
 pub use egui_winit;
 
-use egui_winit::winit::event_loop::EventLoopWindowTarget;
+use egui_winit::winit::event_loop::ActiveEventLoop;
 pub use egui_winit::EventResponse;
 
 // ----------------------------------------------------------------------------
@@ -33,11 +33,11 @@ pub struct EguiGlium {
 }
 
 impl EguiGlium {
-    pub fn new<E>(
+    pub fn new(
         viewport_id: egui::ViewportId,
         display: &glium::Display<WindowSurface>,
         window: &winit::window::Window,
-        event_loop: &EventLoopWindowTarget<E>,
+        event_loop: &ActiveEventLoop,
     ) -> Self {
         let painter = crate::Painter::new(display);
 
@@ -47,6 +47,7 @@ impl EguiGlium {
             viewport_id,
             event_loop,
             Some(pixels_per_point),
+            None,
             Some(painter.max_texture_side()),
         );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,10 +15,9 @@
 mod painter;
 use glium::glutin::surface::WindowSurface;
 pub use painter::Painter;
+use raw_window_handle::HasDisplayHandle;
 
 pub use egui_winit;
-
-use egui_winit::winit::event_loop::ActiveEventLoop;
 pub use egui_winit::EventResponse;
 
 // ----------------------------------------------------------------------------
@@ -37,7 +36,7 @@ impl EguiGlium {
         viewport_id: egui::ViewportId,
         display: &glium::Display<WindowSurface>,
         window: &winit::window::Window,
-        event_loop: &ActiveEventLoop,
+        event_loop: &dyn HasDisplayHandle,
     ) -> Self {
         let painter = crate::Painter::new(display);
 


### PR DESCRIPTION
This updates:

* `egui`: `0.26.2` -> `0.29`
* `egui-winit`: `0.26.2` -> `0.29`
* `glium`: `0.34` -> `0.36`
* `winit`: `0.29` -> `0.30`
* `egui_demo_lib`: `0.26.2` -> `0.29`

I have ported both examples and they seem to run properly (tested on MacOS Sequoia 15.0.1)

The diff is quite involved because winit has a bit of a paradigm shift from a callback-based event system to a trait-based system. And similarly, as `EventLoopWindowTarget` was renamed to `ActiveEventLoop`, and you can only get an `ActiveEventLoop` inside of the trait callbacks, I don't construct the graphics resources until the `resumed()` function on the trait is called, which requires placing the graphics resources in an `Option`. 

Edit - I just realized there was an existing PR for this 😢 