### PR TITLE
Update to glium 0.31

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,11 @@ links = ["egui-winit/links"]
 
 
 [dependencies]
-egui = { version = "0.29", default-features = false, features = [
+egui = { version = "0.31", default-features = false, features = [
   "bytemuck",
   "default_fonts"
 ] }
-egui-winit = { version = "0.29", default-features = false }
+egui-winit = { version = "0.31", default-features = false }
 
 ahash = { version = "0.8", default-features = false, features = [
   "no-rng", # we don't need DOS-protection, so we let users opt-in to it instead
@@ -51,5 +51,5 @@ document-features = { version = "0.2", optional = true }
 
 
 [dev-dependencies]
-egui_demo_lib = { version = "0.29", default-features = false }
+egui_demo_lib = { version = "0.31", default-features = false }
 image = { version = "0.24", default-features = false, features = ["png"] }


### PR DESCRIPTION
I ran the tests and the examples and it seems no real changes were needed to go from glium 0.29 to 0.31.